### PR TITLE
#211 Demo workflow: add backend health check route

### DIFF
--- a/backend/app.js
+++ b/backend/app.js
@@ -13,6 +13,7 @@ dotenv.config({path:'./.env.local'})
 
 
 
+app.use('/api/health',require('./routes/health-route'));
 app.use('/api/fdata',require('./routes/fdata-route'));
 app.use('/api/sdata',require('./routes/sdata-route'));
 

--- a/backend/routes/health-route.js
+++ b/backend/routes/health-route.js
@@ -1,0 +1,8 @@
+const express=require('express')
+const router=express.Router()
+
+router.get('',(req,res)=>{
+    res.status(200).json({ status: 'ok' })
+})
+
+module.exports = router


### PR DESCRIPTION
Closes #211

## Summary
- add backend GET /api/health route
- return JSON status payload for a lightweight health check

## Validation
- PASS: node --check .\\app.js
- PASS: node --check .\\routes\\health-route.js
- BLOCKED: live smoke test could not run because backend dependencies are not installed in this workspace (xpress missing)