### PR TITLE
#212 Demo workflow: add frontend empty-state message for form list

### DIFF
--- a/frontend/src/components/form/form.js
+++ b/frontend/src/components/form/form.js
@@ -55,7 +55,8 @@ function Form({ setSelectform, selectform }) {
   }
   else if (data === undefined || data.length === 0) {
     return (
-      <div className="sub"><h1 style={{"display":"inline","margin":"10px"}}>Create Form</h1>{console.log("nodata")}
+      <div className="sub"><h1 style={{"display":"inline","margin":"10px"}}>Create Form</h1>
+      <div>No forms are available yet. Create a form to get started.</div>
       <Link to="create">
       <Addform/>
       </Link>


### PR DESCRIPTION
Closes #212

## Summary
- add a clearer empty-state message for the frontend form list
- preserve existing behavior when forms are present

## Validation
- BLOCKED: 
px eslint src/components/form/form.js could not run because frontend dependencies are not installed
- BLOCKED: 
pm test -- --watchAll=false could not run because eact-scripts is missing
- BLOCKED: 
pm run build could not run because eact-scripts is missing